### PR TITLE
Drop support to Julia v0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
   - osx
 julia:
   - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ os:
   - linux
   - osx
 julia:
-  # - release
-  - 0.4
   - 0.5
   - nightly
 notifications:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 @osx Homebrew
 BinDeps
 Compat 0.17.0
-julia 0.4
+julia 0.5

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-    - JULIAVERSION: "julialang/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
-    - JULIAVERSION: "julialang/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
     - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
     - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
     - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"


### PR DESCRIPTION
Based on the comments in #7, this PR drops support to Julia v0.4 to avoid non-concrete types. Soon it is merged, I will proceed and release a minor version Hwloc.jl v0.6.0.