### PR TITLE
Cpu physical cores

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ A shortcut is also provided for the number of (physical) cores:
 
 ```
 import Hwloc
-ncores = Hwloc.cpu_physical_cores()
+ncores = Hwloc.num_physical_cores()
 ```
 
 The L1 cache properties:

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ This may output:
 
 ## Obtaining particular information:
 
-The number of cores and virtual cores (PUs):
+The number of (physical) cores and virtual cores (PUs):
 
 ```
 import Hwloc
@@ -107,6 +107,13 @@ println("This machine has $ncores cores and $npus PUs (processing units)")
 This may print:
 ```
 This machine has 4 cores and 8 PUs (processing units)
+```
+
+A shortcut is also provided for the number of (physical) cores:
+
+```
+import Hwloc
+ncores = Hwloc.cpu_physical_cores()
 ```
 
 The L1 cache properties:

--- a/src/Hwloc.jl
+++ b/src/Hwloc.jl
@@ -13,7 +13,7 @@ else
     error("Hwloc not properly installed; please run Pkg.build(\"Hwloc\")")
 end
 
-export get_api_version, topology_load, getinfo, histmap
+export get_api_version, topology_load, getinfo, histmap, cpu_physical_cores
 
 
 
@@ -363,6 +363,12 @@ function histmap(obj::Object)
     counts = Dict{Symbol,Int}([(t, 0) for t in obj_types])
     foldl((_,obj)->(counts[obj.type_]+=1; nothing), nothing, obj)
     return counts
+end
+
+# Wrappers for commonly queried info
+function cpu_physical_cores()
+  topo = topology_load()
+  histmap(topo)[:Core]
 end
 
 end

--- a/src/Hwloc.jl
+++ b/src/Hwloc.jl
@@ -13,7 +13,7 @@ else
     error("Hwloc not properly installed; please run Pkg.build(\"Hwloc\")")
 end
 
-export get_api_version, topology_load, getinfo, histmap, cpu_physical_cores
+export get_api_version, topology_load, getinfo, histmap, num_physical_cores
 
 
 
@@ -366,7 +366,7 @@ function histmap(obj::Object)
 end
 
 # Wrappers for commonly queried info
-function cpu_physical_cores()
+function num_physical_cores()
   topo = topology_load()
   histmap(topo)[:Core]
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,6 +16,7 @@ println("Histogram map:")
 println(counts)
 @test counts[:Core] > 0
 @test counts[:PU] > 0
+@test num_physical_cores() == counts[:Core]
 
 # Hierarchical summary of topology
 hinfo = Hwloc.getinfo(topology)


### PR DESCRIPTION
Fix #10.

This is a simple utility for the most commonly used query. I appreciate if you can review it.

I thought of saving the result in a constant CPU_PHYSICAL_CORES but I am not sure it is safe to assume the number will be the same across a cluster of computers for example.