### PR TITLE
Introduce collectobjects(topology,:objtype) + convenience methods

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ julia = "1.3"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+CpuId = "adafc99b-e345-5852-983c-f28acb93d879"
 
 [targets]
-test = ["Test"]
+test = ["Test", "CpuId"]

--- a/README.md
+++ b/README.md
@@ -119,12 +119,11 @@ ncores = Hwloc.num_physical_cores()
 
 
 The L1 cache properties:
-
 ```
 import Hwloc
 topology = Hwloc.topology_load()
-l1caches=Hwloc.collectobjects(topology,:L1Cache) |> Hwloc.attributes
-println("L1 cache information: $(first(l1caches))")
+l1caches_attributes = Hwloc.attributes.(collectobjects(topology,:L1Cache))
+println("L1 cache information: $(first(l1caches_attributes))")
 ```
 
 This may print:

--- a/README.md
+++ b/README.md
@@ -116,16 +116,28 @@ import Hwloc
 ncores = Hwloc.num_physical_cores()
 ```
 
+
+
 The L1 cache properties:
 
 ```
 import Hwloc
 topology = Hwloc.topology_load()
-l1cache = first(t for t in topology if t.type_ == :L1Cache && t.attr.depth == 1).attr
-println("L1 cache information: $l1cache")
+l1caches=Hwloc.collectobjects(topology,:L1Cache) |> Hwloc.attributes
+println("L1 cache information: $(first(l1caches))")
 ```
 
 This may print:
 ```
 L1 cache information: Cache{size=32768,depth=1,linesize=64,associativity=0,type=Data}
 ```
+
+For the interesting cache sizes, there are some shortcuts:
+```
+@show Hwloc.l3cache_sizes();
+Hwloc.l3cache_sizes() = [12582912]
+@show Hwloc.l2cache_sizes();
+Hwloc.l2cache_sizes() = [262144, 262144, 262144, 262144, 262144, 262144]
+@show Hwloc.l1cache_sizes()
+Hwloc.l1cache_sizes() = [32768, 32768, 32768, 32768, 32768, 32768]
+````

--- a/src/Hwloc.jl
+++ b/src/Hwloc.jl
@@ -455,21 +455,9 @@ end
 
 
 # Collect objects of given type from topology.
-function collectobjects(t::Hwloc.Object,type_::Union{String,Symbol}, objects_found=nothing)
-    if objects_found==nothing
-        objects_found=[]
-    end
-    t.type_==Symbol(type_) &&  push!(objects_found,t)
-    map(child->collectobjects(child,type_,objects_found),t.children)
-    objects_found
-end
+collectobjects(t::Object, type_::Symbol) = collect(Iterators.filter(obj -> obj.type_ == type_, t))
 
-
-# Retrieve attributes of collected objects.
-# E.g.  `collectobjects(topology,:L2Cache) |> attributes`
-# gives the list of L2 cache data.
-attributes(objects)=map(x->x.attr,objects)
-
+attributes(obj::Object)=obj.attr
 
 # Return number of cores
 function num_physical_cores()
@@ -480,16 +468,16 @@ end
 
 # Return number of processor packages (sockets). Compute servers usually consist
 # of several packages which in turn contain several cores.
-num_packages()=collectobjects(Hwloc.topology_load(),:Package) |> Base.length
+num_packages() = count(obj->obj.type_ == :Package, Hwloc.topology_load())
 
 # Return L3 cache sizes (in Bytes) of each package.
 # Usually, L3 cache is shared by all cores in a package. 
-l3cache_sizes()=map(obj->obj.attr.size,collectobjects(Hwloc.topology_load(),:L3Cache))
+l3cache_sizes() = map(obj->obj.attr.size, Iterators.filter(obj->obj.type_ == :L3Cache, Hwloc.topology_load()))
 
 # Return L2 cache sizes (in Bytes) of each core.
-l2cache_sizes()=map(obj->obj.attr.size,collectobjects(Hwloc.topology_load(),:L2Cache))
+l2cache_sizes() = map(obj->obj.attr.size, Iterators.filter(obj->obj.type_ == :L2Cache, Hwloc.topology_load()))
 
 # Return L1 cache sizes (in Bytes) of each core.
-l1cache_sizes()=map(obj->obj.attr.size,collectobjects(Hwloc.topology_load(),:L1Cache))
+l1cache_sizes() = map(obj->obj.attr.size, Iterators.filter(obj->obj.type_ == :L1Cache, Hwloc.topology_load()))
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using Hwloc
 using Test
+using CpuId
 
 version = Hwloc.get_api_version()
 @test isa(version, VersionNumber)
@@ -17,6 +18,31 @@ println(counts)
 @test counts[:Core] > 0
 @test counts[:PU] > 0
 @test num_physical_cores() == counts[:Core]
+@test num_packages() == counts[:Package]
+
+# Cache sizes
+allequal(xs) = all(x == first(xs) for x in xs)
+l1, l2, l3 = CpuId.cachesize()
+
+l1s = l1cache_sizes()
+@test length(l1s) == counts[:L1Cache]
+if allequal(l1s) # running on a machine with equal caches
+    @test first(l1s) == l1
+end
+l2s = l2cache_sizes()
+@test length(l2s) == counts[:L2Cache]
+if allequal(l2s) # running on a machine with equal caches
+    @test first(l2s) == l2
+end
+l3s = l3cache_sizes()
+@test length(l3s) == counts[:L3Cache]
+if allequal(l3s) # running on a machine with equal caches
+    @test first(l3s) == l3
+end
+
+@test typeof(collectobjects(topology, :L1Cache)) == Vector{Hwloc.Object}
+@test length(collectobjects(topology, :L1Cache)) == counts[:L1Cache]
+@test first(collectobjects(topology, :L1Cache)).type_ == :L1Cache
 
 # Hierarchical summary of topology
 hinfo = Hwloc.getinfo(topology)


### PR DESCRIPTION
Hi, I was struggling with obtaining different cache sizes from the example in the README (it didn't work for me), so I rolled my own and propose this addition to the higher level API.

Rationale:

Besides of num_physical_cores(), additional information is of
prevalent interest:

num_packages(): number of processor packages; Usually, each corresponds
                to one NUMA node with its localized memory. The existence of
                everal NUMA nodes tells about several lanes to memory
l*cache_sizes(): These are of pre-eminent interest with respect to performance
                on objects with larger memory footprint.
