### PR TITLE
Fix L1 cache example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ The L1 cache properties:
 ```
 import Hwloc
 topology = Hwloc.topology_load()
-l1cache = first(filter(t->t.type_==:Cache && t.attr.depth==1, topology)).attr
+l1cache = first(t for t in topology if t.type_ == :L1Cache && t.attr.depth == 1).attr
 println("L1 cache information: $l1cache")
 ```
 


### PR DESCRIPTION
`filter` doesn't work since Julia 1.0 as it requires indexable objects.