### PR TITLE
Print flat sub-hierarchy in single line

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,36 +28,24 @@ Machine (16.0 GB)
     Package L#0 P#0 (16.0 GB)
         NUMANode (16.0 GB)
         L3 (12.0 MB)
-            L2 (256.0 KB)
-                L1 (32.0 KB)
-                    Core L#0 P#0 
-                        PU L#0 P#0 
-                        PU L#1 P#1 
-            L2 (256.0 KB)
-                L1 (32.0 KB)
-                    Core L#1 P#1 
-                        PU L#2 P#2 
-                        PU L#3 P#3 
-            L2 (256.0 KB)
-                L1 (32.0 KB)
-                    Core L#2 P#2 
-                        PU L#4 P#4 
-                        PU L#5 P#5 
-            L2 (256.0 KB)
-                L1 (32.0 KB)
-                    Core L#3 P#3 
-                        PU L#6 P#6 
-                        PU L#7 P#7 
-            L2 (256.0 KB)
-                L1 (32.0 KB)
-                    Core L#4 P#4 
-                        PU L#8 P#8 
-                        PU L#9 P#9 
-            L2 (256.0 KB)
-                L1 (32.0 KB)
-                    Core L#5 P#5 
-                        PU L#10 P#10 
-                        PU L#11 P#11 
+            L2 (256.0 kB) + L1 (32.0 kB) + Core L#0 P#0 
+                PU L#0 P#0 
+                PU L#1 P#1 
+            L2 (256.0 kB) + L1 (32.0 kB) + Core L#1 P#1 
+                PU L#2 P#2 
+                PU L#3 P#3 
+            L2 (256.0 kB) + L1 (32.0 kB) + Core L#2 P#2 
+                PU L#4 P#4 
+                PU L#5 P#5 
+            L2 (256.0 kB) + L1 (32.0 kB) + Core L#3 P#3 
+                PU L#6 P#6 
+                PU L#7 P#7 
+            L2 (256.0 kB) + L1 (32.0 kB) + Core L#4 P#4 
+                PU L#8 P#8 
+                PU L#9 P#9 
+            L2 (256.0 kB) + L1 (32.0 kB) + Core L#5 P#5 
+                PU L#10 P#10 
+                PU L#11 P#11
 ```
 
 Often, one is only interested in a summary of this topology.
@@ -161,11 +149,9 @@ julia> Hwloc.attributes(l2cache)
 Cache{size=262144,depth=2,linesize=64,associativity=4,type=Unified}
 
 julia> l2cache |> print_topology
-            L2 (256.0 KB)
-                L1 (32.0 KB)
-                    Core L#0 P#0 
-                        PU L#0 P#0 
-                        PU L#1 P#1
+L2 (256.0 kB) + L1 (32.0 kB) + Core L#0 P#0 
+    PU L#0 P#0 
+    PU L#1 P#1
 ```
 
 Topology elements of type `Hwloc.Object` also are Julia iterators. One can thus readily traverse the corresponding part of the topology tree:


### PR DESCRIPTION
Before the PR:

```Julia
julia> topology()
Machine (16.0 GB)
    Package L#0 P#0 (16.0 GB)
        NUMANode (16.0 GB)
        L3 (12.0 MB)
            L2 (256.0 kB)
                L1 (32.0 kB)
                    Core L#0 P#0 
                        PU L#0 P#0 
                        PU L#1 P#1 
            L2 (256.0 kB)
                L1 (32.0 kB)
                    Core L#1 P#1 
                        PU L#2 P#2 
                        PU L#3 P#3 
            L2 (256.0 kB)
                L1 (32.0 kB)
                    Core L#2 P#2 
                        PU L#4 P#4 
                        PU L#5 P#5 
            L2 (256.0 kB)
                L1 (32.0 kB)
                    Core L#3 P#3 
                        PU L#6 P#6 
                        PU L#7 P#7 
            L2 (256.0 kB)
                L1 (32.0 kB)
                    Core L#4 P#4 
                        PU L#8 P#8 
                        PU L#9 P#9 
            L2 (256.0 kB)
                L1 (32.0 kB)
                    Core L#5 P#5 
                        PU L#10 P#10 
                        PU L#11 P#11
```

After the PR:

```Julia
julia> topology()
Machine (16.0 GB)
    Package L#0 P#0 (16.0 GB)
        NUMANode (16.0 GB)
        L3 (12.0 MB)
            L2 (256.0 kB) + L1 (32.0 kB) + Core L#0 P#0 
                PU L#0 P#0 
                PU L#1 P#1 
            L2 (256.0 kB) + L1 (32.0 kB) + Core L#1 P#1 
                PU L#2 P#2 
                PU L#3 P#3 
            L2 (256.0 kB) + L1 (32.0 kB) + Core L#2 P#2 
                PU L#4 P#4 
                PU L#5 P#5 
            L2 (256.0 kB) + L1 (32.0 kB) + Core L#3 P#3 
                PU L#6 P#6 
                PU L#7 P#7 
            L2 (256.0 kB) + L1 (32.0 kB) + Core L#4 P#4 
                PU L#8 P#8 
                PU L#9 P#9 
            L2 (256.0 kB) + L1 (32.0 kB) + Core L#5 P#5 
                PU L#10 P#10 
                PU L#11 P#11
```

Inspired by the `lstopo` output:

```
➜  ~/repos/Hwloc.jl git:(master) lstopo
Machine (16GB total)
  Package L#0
    NUMANode L#0 (P#0 16GB)
    L3 L#0 (12MB)
      L2 L#0 (256KB) + L1d L#0 (32KB) + L1i L#0 (32KB) + Core L#0
        PU L#0 (P#0)
        PU L#1 (P#1)
      L2 L#1 (256KB) + L1d L#1 (32KB) + L1i L#1 (32KB) + Core L#1
        PU L#2 (P#2)
        PU L#3 (P#3)
      L2 L#2 (256KB) + L1d L#2 (32KB) + L1i L#2 (32KB) + Core L#2
        PU L#4 (P#4)
        PU L#5 (P#5)
      L2 L#3 (256KB) + L1d L#3 (32KB) + L1i L#3 (32KB) + Core L#3
        PU L#6 (P#6)
        PU L#7 (P#7)
      L2 L#4 (256KB) + L1d L#4 (32KB) + L1i L#4 (32KB) + Core L#4
        PU L#8 (P#8)
        PU L#9 (P#9)
      L2 L#5 (256KB) + L1d L#5 (32KB) + L1i L#5 (32KB) + Core L#5
        PU L#10 (P#10)
        PU L#11 (P#11)
  CoProc(OpenCL) "opencl0d1"
  CoProc(OpenCL) "opencl0d2"
```