### PR TITLE
WIP: Add support for PCI devices

### DIFF
--- a/src/libhwloc.jl
+++ b/src/libhwloc.jl
@@ -321,20 +321,22 @@ function load(hobj::hwloc_obj_t)
     children = Object[load(child) for child in obj_children]
 
     memory_children = Object[]
-    if obj.memory_arity != 0 && obj.memory_first_child != C_NULL
-        push!(memory_children, load(obj.memory_first_child))
+    if obj.memory_arity != 0
+        memory_child = obj.memory_first_child 
+        while memory_child != C_NULL
+            push!(memory_children, load(memory_child))
+            memory_child = unsafe_load(memory_child).next_sibling
+        end
     end
 
     io_children = Object[]
-    @show obj.io_arity
     if obj.io_arity != 0 
         io_child = obj.io_first_child
         while io_child != C_NULL
-            push!(io_children, load(obj.io_first_child))
+            push!(io_children, load(io_child))
             io_child = unsafe_load(io_child).next_sibling
         end
     end
-    @show io_children
 
     topo = Object(type_, os_index, name, attr, mem, depth, logical_index, children, memory_children, io_children)
     return topo

--- a/src/libhwloc.jl
+++ b/src/libhwloc.jl
@@ -183,6 +183,12 @@ struct PCIDevAttr <: Attribute
     revision::Int
     linkspeed::Float32
 end
+function PCIDevAttr(ha::hwloc_pcidev_attr_s)
+    return PCIDevAttr(
+        ha.domain, ha.bus, ha.dev, ha.func, ha.class_id,
+        ha.vendor_id, ha.device_id, ha.subvendor_id, ha.subdevice_id,
+        ha.revision, ha.linkspeed)
+end
 # TODO: expand this
 show(io::IO, a::PCIDevAttr) = print(io, "PCIDev{...}")
 
@@ -232,7 +238,8 @@ function load_attr(hattr::Ptr{Cvoid}, type_::Symbol)
     elseif type_==:Bridge
         return NullAttr()
     elseif type_==:PCI_Device
-        return NullAttr()
+        ha = unsafe_load(convert(Ptr{hwloc_pcidev_attr_s}, hattr))
+        return PCIDevAttr(ha)
     elseif type_==:OS_Device
         return NullAttr()
     elseif type_==:Die

--- a/src/lowlevel_api.jl
+++ b/src/lowlevel_api.jl
@@ -98,7 +98,9 @@ function PCIDevAttr(ha::hwloc_pcidev_attr_s)
         ha.revision, ha.linkspeed)
 end
 # TODO: expand this
-show(io::IO, a::PCIDevAttr) = print(io, "PCIDev{...}")
+function show(io::IO, a::PCIDevAttr)
+    print(io, "PCIDev(domain=$(a.domain), bus=$(a.bus), func=$(a.func), class_id=$(a.class_id), vendor_id=$(a.vendor_id), device_id=$(a.device_id), subvendor_id=$(a.subvendor_id), subdevice_id=$(a.subdevice_id), revision=$(a.revision), linkspeed=$(a.linkspeed))")
+end
 
 # type BridgeAttr <: Attribute end
 
@@ -234,9 +236,6 @@ function load(hobj::hwloc_obj_t)
     children = Object[load(child) for child in obj_children]
 
     memory_children = Object[]
-    # if obj.memory_arity != C_NULL && obj.memory_first_child != C_NULL
-    #     push!(memory_children, load(obj.memory_first_child))
-    # end
     if obj.memory_arity != 0
         memory_child = obj.memory_first_child 
         while memory_child != C_NULL
@@ -262,9 +261,14 @@ function load(hobj::hwloc_obj_t)
 end
 
 
-function topology_init()
+function topology_init(;get_io=true)
     r_htopo = Ref{hwloc_topology_t}()
     hwloc_topology_init(r_htopo)
+    if get_io
+        hwloc_topology_set_io_types_filter(
+            r_htopo[], LibHwloc.HWLOC_TYPE_FILTER_KEEP_ALL
+        )
+    end
     return r_htopo[]
 end
 


### PR DESCRIPTION
Following the changeover to Clang.jl introduced by #64, this PR will update #63 to used the Clang.jl-generated wrappers. This PR changes the WIP's API for enabling PCI devices slightly:

```julia
julia> htopo = Hwloc.topology_init()
Ptr{Hwloc.LibHwloc.hwloc_topology} @0x0000557acb6af820

julia> Hwloc.hwloc_topology_set_io_types_filter(htopo, Hwloc.LibHwloc.HWLOC_TYPE_FILTER_KEEP_ALL)
0

julia> obj = Hwloc.topology_load(htopo)
Hwloc.Object: Machine

julia> obj.io_children
1-element Vector{Hwloc.Object}:
 Hwloc.Object: Bridge

julia> first(obj.io_children).io_children
25-element Vector{Hwloc.Object}:
 Hwloc.Object: PCI_Device
 Hwloc.Object: PCI_Device
 Hwloc.Object: PCI_Device
 Hwloc.Object: Bridge
 Hwloc.Object: Bridge
 Hwloc.Object: Bridge
 Hwloc.Object: PCI_Device
 Hwloc.Object: PCI_Device
 Hwloc.Object: PCI_Device
 Hwloc.Object: PCI_Device
 Hwloc.Object: PCI_Device
 Hwloc.Object: PCI_Device
 Hwloc.Object: PCI_Device
 Hwloc.Object: PCI_Device
 Hwloc.Object: PCI_Device
 Hwloc.Object: PCI_Device
 Hwloc.Object: PCI_Device
 Hwloc.Object: PCI_Device
 Hwloc.Object: Bridge
 Hwloc.Object: Bridge
 Hwloc.Object: PCI_Device
 Hwloc.Object: PCI_Device
 Hwloc.Object: PCI_Device
 Hwloc.Object: PCI_Device
 Hwloc.Object: PCI_Device

```