### PR TITLE
Iterate mem_children, children, io_children

### DIFF
--- a/ext/HwlocTrees.jl
+++ b/ext/HwlocTrees.jl
@@ -29,7 +29,7 @@ function AbstractTrees.children(node::Hwloc.Object)
 end
 
 function AbstractTrees.children(node::HwlocTreeNode)
-    tuple(node.children..., node.memory_children..., node.io_children...)
+    tuple(node.memory_children..., node.children..., node.io_children...)
 end
 
 AbstractTrees.nodevalue(n::HwlocTreeNode) = n.object

--- a/src/lowlevel_api.jl
+++ b/src/lowlevel_api.jl
@@ -239,7 +239,7 @@ IteratorEltype(::Type{Object}) = Base.HasEltype()
 eltype(::Type{Object}) = Object
 isempty(::Object) = false
 function iterate(obj::Object)
-    state = vcat(obj.children, obj.memory_children, obj.io_children)
+    state = vcat(obj.memory_children, obj.children, obj.io_children)
     return obj, state
 end
 function iterate(::Object, state::Vector{Object})
@@ -247,9 +247,9 @@ function iterate(::Object, state::Vector{Object})
     # depth-first traversal
     # obj = shift!(state)
     obj, state = state[1], state[2:end]
+    prepend!(state, obj.io_children)
     prepend!(state, obj.children)
     prepend!(state, obj.memory_children)
-    prepend!(state, obj.io_children)
     return obj, state
 end
 # length(obj::Object) = mapreduce(x->1, +, obj)

--- a/src/lowlevel_api.jl
+++ b/src/lowlevel_api.jl
@@ -247,6 +247,10 @@ function iterate(::Object, state::Vector{Object})
     # depth-first traversal
     # obj = shift!(state)
     obj, state = state[1], state[2:end]
+    # prepend! children groups to state so that they will be iterated before
+    # siblings.  The iteration order is memory_children, children, io_children
+    # to match lstopo ordering, but we must prepend! in the opposite order to
+    # ensure that memory_children are iterated first.
     prepend!(state, obj.io_children)
     prepend!(state, obj.children)
     prepend!(state, obj.memory_children)


### PR DESCRIPTION
Change the iteration order to make it match with `print_topology` and `lstopo` iteration order.  In addition to improved consistency, this is also motivated by the desire to have NUMANode objects be seen before other siblings and their descendants.