### PR TITLE
Make cpu kind information available

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,51 @@ Hwloc.l2cache_sizes() = [262144, 262144, 262144, 262144, 262144, 262144]
 Hwloc.l3cache_sizes() = [12582912]
 ````
 
+### Different kind of CPU cores
+
+Some systems have CPU cores of differents kinds, like, e.g., efficiency and performance cores. With Hwloc.jl, you can query the number of different kinds and the count of CPU cores for each kind. For example, on Mac mini M1 (4 efficiency and 4 performance cores):
+
+```julia
+julia> using Hwloc
+
+julia> num_cpukinds()
+2
+
+julia> num_virtual_cores_cpukinds()
+2-element Vector{Int64}:
+ 4
+ 4
+```
+
+You can also see which PU belongs to which CPU kind by passing `cpukind=true` to `topology`:
+
+```julia
+julia> topology(; cpukind=true)
+
+Machine (3.49 GB)
+    Package L#0 P#0 (3.49 GB)
+        NUMANode (3.49 GB)
+        L2 (4.0 MB)
+            L1 (64.0 kB) + Core L#0 P#0
+                PU L#0 P#0 (1, DarwinCompatible=apple,icestorm;ARM,v8)
+            L1 (64.0 kB) + Core L#1 P#1
+                PU L#1 P#1 (1, DarwinCompatible=apple,icestorm;ARM,v8)
+            L1 (64.0 kB) + Core L#2 P#2
+                PU L#2 P#2 (1, DarwinCompatible=apple,icestorm;ARM,v8)
+            L1 (64.0 kB) + Core L#3 P#3
+                PU L#3 P#3 (1, DarwinCompatible=apple,icestorm;ARM,v8)
+        L2 (12.0 MB)
+            L1 (128.0 kB) + Core L#4 P#4
+                PU L#4 P#4 (2, DarwinCompatible=apple,firestorm;ARM,v8)
+            L1 (128.0 kB) + Core L#5 P#5
+                PU L#5 P#5 (2, DarwinCompatible=apple,firestorm;ARM,v8)
+            L1 (128.0 kB) + Core L#6 P#6
+                PU L#6 P#6 (2, DarwinCompatible=apple,firestorm;ARM,v8)
+            L1 (128.0 kB) + Core L#7 P#7
+                PU L#7 P#7 (2, DarwinCompatible=apple,firestorm;ARM,v8)
+    CoProc(OpenCL) "opencl0d0"
+```
+
 ### Manual access
 
 To manually traverse and investigate the system topology tree, one may use `gettopology()` to

--- a/src/Hwloc.jl
+++ b/src/Hwloc.jl
@@ -10,7 +10,7 @@ include("lowlevel_api.jl")
 include("highlevel_api.jl")
 
 export topology, gettopology, topology_info, getinfo, print_topology, topology_graphical
-export num_physical_cores, num_virtual_cores, num_packages, num_numa_nodes, num_cpukinds, num_cores_cpukinds
+export num_physical_cores, num_virtual_cores, num_packages, num_numa_nodes, num_cpukinds, num_virtual_cores_cpukinds
 export cachesize, cachelinesize
 export hwloc_typeof, hwloc_isa, collectobjects
 

--- a/src/Hwloc.jl
+++ b/src/Hwloc.jl
@@ -10,7 +10,7 @@ include("lowlevel_api.jl")
 include("highlevel_api.jl")
 
 export topology, gettopology, topology_info, getinfo, print_topology, topology_graphical
-export num_physical_cores, num_virtual_cores, num_packages, num_numa_nodes
+export num_physical_cores, num_virtual_cores, num_packages, num_numa_nodes, num_cpukinds, num_cores_cpukinds
 export cachesize, cachelinesize
 export hwloc_typeof, hwloc_isa, collectobjects
 

--- a/src/highlevel_api.jl
+++ b/src/highlevel_api.jl
@@ -430,7 +430,9 @@ in the topology.
 num_cpukinds() = length(get_cpukind_info())
 
 """
-Get the number of CPU cores in the topology  that are of the same kind.
+For each kind of CPU cores, get the number of cores in the topology that are of that kind.
+Typically, sorting is by efficiency (descending order). Hence, efficiency cores come before
+performance cores.
 """
 function num_cores_cpukinds()
     cki = get_cpukind_info()

--- a/src/highlevel_api.jl
+++ b/src/highlevel_api.jl
@@ -436,5 +436,5 @@ performance cores.
 """
 function num_cores_cpukinds()
     cki = get_cpukind_info()
-    return [count_set_bits(cki[i].mask) for i in eachindex(cki)]
+    return [isnothing(cki[i]) ? nothing : count_set_bits(cki[i].mask) for i in eachindex(cki)]
 end

--- a/src/highlevel_api.jl
+++ b/src/highlevel_api.jl
@@ -52,7 +52,7 @@ end
         indent = "", newline = true, prefix = "", minimal=true
     )
 
-Prints the topology of the given `obj` as a tree to `io`. 
+Prints the topology of the given `obj` as a tree to `io`.
 
 **Note:** some systems have a great deal of extra PCI devices (think USB
 bridges, and the many many device classes on custom systems like HPC clusters).
@@ -60,9 +60,9 @@ In order to mimmic the behaviour of the `lstopo` command, we ommit these devices
 unless `minimal=false`.
 """
 function print_topology(
-        io::IO = stdout, obj::Object = gettopology();
-        indent = "", newline = true, prefix = "", minimal=true
-    )
+    io::IO=stdout, obj::Object=gettopology();
+    indent="", newline=true, prefix="", minimal=true
+)
     t = hwloc_typeof(obj)
 
     idxstr = t in (:Package, :Core, :PU) ? "L#$(obj.logical_index) P#$(obj.os_index) " : ""
@@ -74,10 +74,10 @@ function print_topology(
 
     if t in (:L1Cache, :L2Cache, :L3Cache, :L1ICache)
         tstr = first(string(t), 2)
-        attrstr = "("*_bytes2string(obj.attr.size)*")"
+        attrstr = "(" * _bytes2string(obj.attr.size) * ")"
     elseif t == :Bridge
         if obj.attr.upstream_type == HWLOC_OBJ_BRIDGE_HOST
-            tstr    = "HostBridge"
+            tstr = "HostBridge"
             attrstr = ""
         else
             tstr = "PCIBridge"
@@ -85,7 +85,7 @@ function print_topology(
         end
     elseif t == :PCI_Device
         class_string = hwloc_pci_class_string(obj.attr.class_id)
-        tstr    = "PCI"
+        tstr = "PCI"
         attrstr = obj.attr.domain == 0 ? "" : @sprintf("%04x:", obj.attr.domain)
         attrstr *= @sprintf("%02x:%02x.%01x",
             obj.attr.bus, obj.attr.dev, obj.attr.func
@@ -116,29 +116,29 @@ function print_topology(
         newline && print(io, "\n", indent)
         print(
             io, prefix, tstr, " ", idxstr, attrstr,
-            obj.mem > 0 ? "("*_bytes2string(obj.mem)*")" : ""
+            obj.mem > 0 ? "(" * _bytes2string(obj.mem) * ")" : ""
         )
     else
         return nothing
     end
 
     for memchild in obj.memory_children
-        memstr = "("*_bytes2string(memchild.mem)*")"
+        memstr = "(" * _bytes2string(memchild.mem) * ")"
         println(io)
-        print(io, indent*repeat(" ", 4), string(memchild.type_), " ", memstr)
+        print(io, indent * repeat(" ", 4), string(memchild.type_), " ", memstr)
     end
 
     for child in obj.children
-        no_newline = length(obj.children)==1 && t in (:L3Cache, :L2Cache, :L1Cache)
+        no_newline = length(obj.children) == 1 && t in (:L3Cache, :L2Cache, :L1Cache)
         if no_newline
             print_topology(
                 io, child;
-                indent = indent, newline=false, prefix = " + ", minimal=minimal
+                indent=indent, newline=false, prefix=" + ", minimal=minimal
             )
         else
             print_topology(
                 io, child;
-                indent = indent*repeat(" ", 4), newline=true, minimal=minimal
+                indent=indent * repeat(" ", 4), newline=true, minimal=minimal
             )
         end
     end
@@ -146,7 +146,7 @@ function print_topology(
     for child in obj.io_children
         print_topology(
             io, child;
-            indent=indent*repeat(" ", 4), newline=true, minimal=minimal
+            indent=indent * repeat(" ", 4), newline=true, minimal=minimal
         )
     end
 
@@ -163,7 +163,7 @@ Pass `reload=true` in order to force reload.
 function gettopology(htopo=nothing; reload=false, io=true)
     if reload || (!isassigned(machine_topology))
         if isnothing(htopo)
-            htopo=topology_init(;io=io)
+            htopo = topology_init(; io=io)
         end
         machine_topology[] = topology_load(htopo)
     end
@@ -182,21 +182,21 @@ topology(topo=gettopology()) = print_topology(topo)
 Prints a summary of the system topology (loosely similar to `hwloc-info`).
 """
 function topology_info(topo=gettopology())
-    nodes = Tuple{Symbol, Int64, String}[]
+    nodes = Tuple{Symbol,Int64,String}[]
     for subobj in topo
-        idx = findfirst(t->t[1] == subobj.type_, nodes)
+        idx = findfirst(t -> t[1] == subobj.type_, nodes)
         if isnothing(idx)
             attrstr = ""
             subobj.mem > 0 && (attrstr = " ($(_bytes2string(subobj.mem)))")
             subobj.type_ ∈ (:L1Cache, :L2Cache, :L3Cache) && (attrstr = " ($(_bytes2string(subobj.attr.size)))")
             push!(nodes, (subobj.type_, 1, attrstr))
         else
-            nodes[idx] = (subobj.type_, nodes[idx][2]+1, nodes[idx][3])
+            nodes[idx] = (subobj.type_, nodes[idx][2] + 1, nodes[idx][3])
         end
     end
 
-    for (i,n) in enumerate(nodes)
-        println(repeat(" ", i-1), "$(n[1]): ", n[2], n[3])
+    for (i, n) in enumerate(nodes)
+        println(repeat(" ", i - 1), "$(n[1]): ", n[2], n[3])
     end
     return nothing
 end
@@ -211,13 +211,13 @@ If the `list_all` kwarg is `true`, then the results Dict will have a key for
 each Hwloc type. **Warning:** a zero count does not necessarily mean that such
 a device is not present -- e.g. the following
 ```
-getinfo(gettopology(;reload=true, io=false); list_all=true) 
+getinfo(gettopology(;reload=true, io=false); list_all=true)
 ```
 will show a `PCI_Device` count of zero, even though those devices are present
 (the zero count is due to the `io=false` kwarg passed to `gettopology`).
 """
 function getinfo(topo=gettopology(); list_all=false)
-    res = list_all ? Dict{Symbol,Int}(t => 0 for t in obj_types) : Dict{Symbol, Int}()
+    res = list_all ? Dict{Symbol,Int}(t => 0 for t in obj_types) : Dict{Symbol,Int}()
     for subobj in topo
         t = hwloc_typeof(subobj)
         res[t] = get!(res, t, 0) + 1
@@ -251,7 +251,7 @@ hwloc_isa(type::Symbol) = obj -> hwloc_typeof(obj) == type
 
 Collects objects of the given hwloc `type` from the (sub-)topology tree `t`.
 """
-collectobjects(type::Symbol, t::Object = gettopology()) = collect(Iterators.filter(hwloc_isa(type), t))
+collectobjects(type::Symbol, t::Object=gettopology()) = collect(Iterators.filter(hwloc_isa(type), t))
 
 """
 The number of physical cores.
@@ -276,29 +276,29 @@ num_numa_nodes() = count(hwloc_isa(:NUMANode), gettopology())
 """
 Returns a vector containing the sizes of all available L3 caches in Bytes.
 """
-l3cache_sizes() = map(obj->obj.attr.size, Iterators.filter(obj->obj.type_ == :L3Cache, gettopology()))
+l3cache_sizes() = map(obj -> obj.attr.size, Iterators.filter(obj -> obj.type_ == :L3Cache, gettopology()))
 """
 Returns a vector containing the L3 cache line sizes in Bytes.
 """
-l3cache_linesizes() = map(obj->obj.attr.linesize, Iterators.filter(obj->obj.type_ == :L3Cache, gettopology()))
+l3cache_linesizes() = map(obj -> obj.attr.linesize, Iterators.filter(obj -> obj.type_ == :L3Cache, gettopology()))
 
 """
 Returns a vector containing the sizes of all available L2 caches in Bytes.
 """
-l2cache_sizes() = map(obj->obj.attr.size, Iterators.filter(obj->obj.type_ == :L2Cache, gettopology()))
+l2cache_sizes() = map(obj -> obj.attr.size, Iterators.filter(obj -> obj.type_ == :L2Cache, gettopology()))
 """
 Returns a vector containing the L2 cache line sizes in Bytes.
 """
-l2cache_linesizes() = map(obj->obj.attr.linesize, Iterators.filter(obj->obj.type_ == :L2Cache, gettopology()))
+l2cache_linesizes() = map(obj -> obj.attr.linesize, Iterators.filter(obj -> obj.type_ == :L2Cache, gettopology()))
 
 """
 Returns a vector containing the sizes of all available L1 caches in Bytes.
 """
-l1cache_sizes() = map(obj->obj.attr.size, Iterators.filter(obj->obj.type_ == :L1Cache, gettopology()))
+l1cache_sizes() = map(obj -> obj.attr.size, Iterators.filter(obj -> obj.type_ == :L1Cache, gettopology()))
 """
 Returns a vector containing the L1 cache line sizes in Bytes.
 """
-l1cache_linesizes() = map(obj->obj.attr.linesize, Iterators.filter(obj->obj.type_ == :L1Cache, gettopology()))
+l1cache_linesizes() = map(obj -> obj.attr.linesize, Iterators.filter(obj -> obj.type_ == :L1Cache, gettopology()))
 
 """
     cachesize()
@@ -414,11 +414,25 @@ The quality of the result might depend on the used terminal and might vary betwe
 
 **Note:** The specific visualization may change between minor versions.
 """
-function topology_graphical(;io=true)
+function topology_graphical(; io=true)
     if io
         run(`$(lstopo_no_graphics()) --no-legend --of txt`)
     else
         run(`$(lstopo_no_graphics()) --no-io --no-legend --of txt`)
     end
     return nothing
+end
+
+"""
+Get the number of different kinds of CPU cores (e.g. efficiency and performance cores)
+in the topology.
+"""
+num_cpukinds() = length(get_cpukind_info())
+
+"""
+Get the number of CPU cores in the topology  that are of the same kind.
+"""
+function num_cores_cpukinds()
+    cki = get_cpukind_info()
+    return [count_set_bits(cki[i].mask) for i in eachindex(cki)]
 end

--- a/src/highlevel_api.jl
+++ b/src/highlevel_api.jl
@@ -436,5 +436,8 @@ performance cores.
 """
 function num_cores_cpukinds()
     cki = get_cpukind_info()
-    return [isnothing(cki[i]) ? nothing : count_set_bits(cki[i].mask) for i in eachindex(cki)]
+    if nothing in cki
+        return nothing
+    end
+    return [count_set_bits(cki[i].mask) for i in eachindex(cki)]
 end

--- a/src/highlevel_api.jl
+++ b/src/highlevel_api.jl
@@ -439,5 +439,5 @@ function num_cores_cpukinds()
     if nothing in cki
         return nothing
     end
-    return [count_set_bits(cki[i].mask) for i in eachindex(cki)]
+    return [count_set_bits(cki[i].masks) for i in eachindex(cki)]
 end

--- a/src/highlevel_api.jl
+++ b/src/highlevel_api.jl
@@ -61,11 +61,15 @@ unless `minimal=false`.
 """
 function print_topology(
     io::IO=stdout, obj::Object=gettopology();
-    indent="", newline=true, prefix="", minimal=true
+    indent="", newline=true, prefix="", minimal=true, cpukinds=false
 )
     t = hwloc_typeof(obj)
 
-    idxstr = t in (:Package, :Core, :PU) ? "L#$(obj.logical_index) P#$(obj.os_index) " : ""
+    idxstr = if t in (:Package, :Core, :PU)
+        "L#$(obj.logical_index) P#$(obj.os_index) "
+    else
+        ""
+    end
     attrstr = string(obj.attr)
 
     # this is set to false whenever minimal == true and the PCI class_id strings
@@ -152,7 +156,7 @@ function print_topology(
 
     return nothing
 end
-print_topology(obj::Object) = print_topology(stdout, obj)
+print_topology(obj::Object; kwargs...) = print_topology(stdout, obj; kwargs...)
 
 """
 Returns the top-level system topology `Object`.
@@ -174,7 +178,7 @@ end
 """
 Prints the system topology as a tree.
 """
-topology(topo=gettopology()) = print_topology(topo)
+topology(topo=gettopology(); kwargs...) = print_topology(topo; kwargs...)
 
 """
     topology_info(topo=gettopology())

--- a/src/highlevel_api.jl
+++ b/src/highlevel_api.jl
@@ -430,11 +430,11 @@ in the topology.
 num_cpukinds() = length(get_cpukind_info())
 
 """
-For each kind of CPU cores, get the number of cores in the topology that are of that kind.
+For each kind of CPU cores, get the number of (virtual) cores in the topology that are of that kind.
 Typically, sorting is by efficiency (descending order). Hence, efficiency cores come before
 performance cores.
 """
-function num_cores_cpukinds()
+function num_virtual_cores_cpukinds()
     cki = get_cpukind_info()
     if nothing in cki
         return nothing

--- a/src/highlevel_api.jl
+++ b/src/highlevel_api.jl
@@ -68,7 +68,7 @@ function print_topology(
     idxstr = if t in (:Package, :Core, :PU)
         s = "L#$(obj.logical_index) P#$(obj.os_index) "
         if t == :PU && cpukinds
-            s = s * "(Kind=$(os_index2cpukind(obj.os_index)))"
+            s = s * "($(os_index2cpukind(obj.os_index)))"
         end
         s
     else

--- a/src/lowlevel_api.jl
+++ b/src/lowlevel_api.jl
@@ -365,12 +365,12 @@ function withbitmap(f; full=false)
 end
 
 function ith_in_mask(mask::Culong, i::Integer)
-    # i starts at 1
-    imask = Culong(0) | (1 << (i - 1))
+    # i starts at 0
+    imask = Culong(0) | (1 << i)
     return !iszero(mask & imask)
 end
 
-count_set_bits(mask::Culong) = count(i -> ith_in_mask(mask, i), 1:64)
+count_set_bits(mask::Culong) = count(i -> ith_in_mask(mask, i), 0:63)
 count_set_bits(masks::Vector{Culong}) = sum(count_set_bits.(masks))
 
 struct HwlocInfo

--- a/src/lowlevel_api.jl
+++ b/src/lowlevel_api.jl
@@ -370,7 +370,7 @@ function ith_in_mask(mask::Culong, i::Integer)
     return !iszero(mask & imask)
 end
 
-count_set_bits(mask::Culong) = count(i -> ith_in_mask(mask, i), 0:63)
+count_set_bits(mask::Culong) = count(i -> ith_in_mask(mask, i), 0:(sizeof(Culong) * 8 - 1))
 count_set_bits(masks::Vector{Culong}) = sum(count_set_bits.(masks))
 
 struct HwlocInfo

--- a/src/lowlevel_api.jl
+++ b/src/lowlevel_api.jl
@@ -436,7 +436,8 @@ function topology_load(htopo=topology_init())
         # more than one CPU kind detected
         _cpukindinfo[] = [get_info_cpukind(htopo, kind_index) for kind_index in 1:ncpukinds]
     else
-        _cpukindinfo[] = [nothing]
+        # CPU kind information is unavailable
+        _cpukindinfo[] = []
     end
 
     hwloc_topology_destroy(htopo)

--- a/src/lowlevel_api.jl
+++ b/src/lowlevel_api.jl
@@ -12,7 +12,7 @@ using ..LibHwloc:
     hwloc_topology_set_userdata, hwloc_topology_get_userdata, var"##Ctag#349",
     var"##Ctag#350", hwloc_cpukinds_get_nr, hwloc_bitmap_alloc, hwloc_bitmap_alloc_full,
     hwloc_bitmap_free, hwloc_cpukinds_get_by_cpuset, hwloc_bitmap_from_ulong,
-    hwloc_cpukinds_get_info, hwloc_info_s, hwloc_bitmap_to_ulong, hwloc_bitmap_nr_ulongs,
+    hwloc_cpukinds_get_info, hwloc_info_s, hwloc_bitmap_nr_ulongs,
     hwloc_topology_get_topology_cpuset, hwloc_bitmap_to_ulongs
 
 using ..LibHwlocExtensions:

--- a/src/lowlevel_api.jl
+++ b/src/lowlevel_api.jl
@@ -433,7 +433,7 @@ function topology_load(htopo=topology_init())
     topo = load(root)
 
     ncpukinds = hwloc_cpukinds_get_nr(htopo, 0)
-    if ncpukinds > 1
+    if ncpukinds > 0
         # more than one CPU kind detected
         # @show cpukind_of_ith_core(htopo, 1)
         # @show cpukind_of_ith_core(htopo, 6)

--- a/src/lowlevel_api.jl
+++ b/src/lowlevel_api.jl
@@ -364,19 +364,6 @@ function withbitmap(f; full=false)
     end
 end
 
-"""
-Return the \"cpu kind\" of the `i`th core (`0 < i <= hwloc_cpukinds_get_nr(htopo, 0)`)
-"""
-function cpukind_of_ith_core(htopo, i)
-    mask = Culong(0) | (1 << (i - 1))
-    local cpukind
-    withbitmap() do bm
-        hwloc_bitmap_from_ulong(bm, mask)
-        cpukind = hwloc_cpukinds_get_by_cpuset(htopo, bm, 0)
-    end
-    return cpukind
-end
-
 function ith_in_mask(mask::Culong, i::Integer)
     # i starts at 1
     imask = Culong(0) | (1 << (i - 1))
@@ -438,8 +425,6 @@ function topology_load(htopo=topology_init())
     ncpukinds = hwloc_cpukinds_get_nr(htopo, 0)
     if ncpukinds > 0
         # more than one CPU kind detected
-        # @show cpukind_of_ith_core(htopo, 1)
-        # @show cpukind_of_ith_core(htopo, 6)
         _cpukindinfo[] = [get_info_cpukind(htopo, kind_index) for kind_index in 1:ncpukinds]
     else
         _cpukindinfo[] = [nothing]

--- a/src/lowlevel_api.jl
+++ b/src/lowlevel_api.jl
@@ -389,7 +389,7 @@ count_set_bits(masks::Vector{Culong}) = sum(count_set_bits.(masks))
 """
 Get information of cores of the same cpukind. `kind_index` starts at 1.
 """
-function get_info_same_cpukind(htopo, kind_index)
+function get_info_cpukind(htopo, kind_index)
     # cpuset = hwloc_topology_get_topology_cpuset(htopo)
     withbitmap() do bm
         infos = Ref{Ptr{hwloc_info_s}}()
@@ -440,7 +440,7 @@ function topology_load(htopo=topology_init())
         # more than one CPU kind detected
         # @show cpukind_of_ith_core(htopo, 1)
         # @show cpukind_of_ith_core(htopo, 6)
-        _cpukindinfo[] = [get_info_same_cpukind(htopo, kind_index) for kind_index in 1:ncpukinds]
+        _cpukindinfo[] = [get_info_cpukind(htopo, kind_index) for kind_index in 1:ncpukinds]
     else
         _cpukindinfo[] = [nothing]
     end

--- a/src/lowlevel_api.jl
+++ b/src/lowlevel_api.jl
@@ -408,7 +408,7 @@ function get_info_cpukind(htopo, kind_index)
 end
 
 const _cpukindinfo = Ref{Union{Nothing,Vector{Union{Nothing,
-    @NamedTuple{masks::Vector{UInt64}, efficiency_rank::Int32, infos::Vector{HwlocInfo}}}}}}(nothing)
+    @NamedTuple{masks::Vector{Culong}, efficiency_rank::Int32, infos::Vector{HwlocInfo}}}}}}(nothing)
 
 function get_cpukind_info()
     isnothing(_cpukindinfo[]) && topology_load()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -129,7 +129,10 @@ import CpuId
 
     @testset "CPU core kinds" begin
         @test num_cpukinds() >= 1
-        @test all(>=(1), num_virtual_cores_cpukinds())
-        @test sum(num_virtual_cores_cpukinds()) == num_virtual_cores()
+        @test typeof(num_virtual_cores_cpukinds()) in (Nothing, Vector{Int64})
+        if !isnothing(num_virtual_cores_cpukinds())
+            @test all(>=(1), num_virtual_cores_cpukinds())
+            @test sum(num_virtual_cores_cpukinds()) == num_virtual_cores()
+        end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -126,4 +126,10 @@ import CpuId
         # check that `children(gettopology)` returns the root of the HwlocTree
         @test children(t).type == :Machine
     end
+
+    @testset "CPU core kinds" begin
+        @test num_cpukinds() >= 1
+        @test all(>=(1), num_virtual_cores_cpukinds())
+        @test sum(num_virtual_cores_cpukinds()) == num_virtual_cores()
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -129,7 +129,7 @@ import CpuId
 
     @testset "CPU core kinds" begin
         @test num_cpukinds() >= 1
-        @test typeof(num_virtual_cores_cpukinds()) in (Nothing, Vector{Int64})
+        @test typeof(num_virtual_cores_cpukinds()) in (Nothing, Vector{Int})
         if !isnothing(num_virtual_cores_cpukinds())
             @test all(>=(1), num_virtual_cores_cpukinds())
             @test sum(num_virtual_cores_cpukinds()) == num_virtual_cores()


### PR DESCRIPTION
Use case: Distinguishing efficiency and performance cores.

* [x] `num_cpukinds()`
* [x] `num_virtual_cores_cpukinds()` 
* [x] show kind information in `topology()`?
* [x] tests
* [x] readme

Close #57