### PR TITLE
`disallowed` option

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,10 +10,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
-          - '1.7'
-          - '1.8'
-          - 'nightly'
+          - '1.10'
+          - 'pre'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 CEnum = "^0.4, ^0.5"
 Hwloc_jll = "^2.8"
 AbstractTrees = "^0.4, ^0.3"
-julia = "^1.6"
+julia = "^1.10"
 
 [extras]
 CpuId = "adafc99b-e345-5852-983c-f28acb93d879"

--- a/src/highlevel_api.jl
+++ b/src/highlevel_api.jl
@@ -182,16 +182,25 @@ Returns the top-level system topology `Object`.
 
 On first call, it loads the topology by querying libhwloc and caches the result.
 Pass `reload=true` in order to force reload.
+
+The keyword arguments `io` (default: `true`) and `disallowed` (default: `false`) may be
+used to select whether IO objects and disallowed objects (e.g. ignoring cgroup restrictions)
+should be included in the topology, respectively.
 """
-function gettopology(htopo=nothing; reload=false, io=true)
+function gettopology(htopo=nothing; reload=false, io=true, disallowed=false)
     if reload || (!isassigned(machine_topology))
         if isnothing(htopo)
-            htopo = topology_init(; io=io)
+            htopo = topology_init(; io=io, disallowed=disallowed)
         end
         machine_topology[] = topology_load(htopo)
     end
 
     return machine_topology[]
+end
+
+function get_cpukind_info()
+    isnothing(_cpukindinfo[]) && gettopology()
+    return _cpukindinfo[]
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,6 +18,7 @@ import CpuId
         @test isa(topo, Hwloc.Object)
         @test hwloc_typeof(topo) ∈ (:Machine, :System)
         @test hwloc_isa(topo, :Machine) || hwloc_isa(topology, :System)
+        # topo = gettoplogy(; disallowed=true)
     end
 
     @testset "Topology (compact info)" begin


### PR DESCRIPTION
(Within a SLURM allocation that doesn't cover the entire node.)

```julia-repl
julia> num_virtual_cores()
20

julia> gettopology(; reload=true, disallowed=true); # reload entire topology with flag set

julia> num_virtual_cores()
256
```

Closes #81